### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,15 @@
-# Terraform Provider for Netdata Cloud
+# Netdata Cloud Terraform Provider
 
-This is the [Terraform](https://www.terraform.io/) provider for the [Netdata Cloud](https://www.netdata.cloud/).
-
-This provider allows you to install and manage Netdata Cloud resources using Terraform.
-
-## Contents
-
-* [Requirements](#requirements)
-* [Getting Started](#getting-started)
+This provider allows you to manage Netdata Cloud resources using Terraform.
 
 ## Requirements
 
-* [Terraform](https://www.terraform.io/downloads.html) v1.1.0 or later
-* [Go](https://golang.org/doc/install) v1.20 or later (to build the provider plugin)
+- Terraform v1.1.0 or later
+- Go v1.20 or later
 
-## Getting Started
+## Installation
 
-* from terraform registry
-
-* from source code
-
-    * setup your [CLI configuration](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers)
-
-    ```console
-    $ cat ~/.terraformrc
-    provider_installation {
-        dev_overrides {
-        "netdata/netdata" = "<your GOBIN directory>"
-        }
-        direct {}
-    }
-    ```
-
-    * build the provider
-
-    ```console
-    $ make local-build
-    ```
+1. Clone this repository.
+2. Build the provider using:
+   ```bash
+   make build


### PR DESCRIPTION
# Terraform Provider for Netdata Cloud

This is the Terraform provider for [Netdata Cloud](https://www.netdata.cloud/). It allows you to manage and automate Netdata Cloud resources using Terraform.

## Requirements

- Terraform v1.1.0 or later
- Go v1.20 or later (only required for building the provider)

## Provider Installation

### Install from Terraform Registry

You can install the provider directly from the Terraform Registry:

```hcl
terraform {
  required_providers {
    netdata = {
      source = "netdata/netdata"
      version = "0.1.0"
    }
  }
}

provider "netdata" {
  api_key = "<YOUR_API_KEY>"
}
Run the following Terraform command to initialize the provider:

terraform init

1. Install from Source
Clone the repository:

git clone https://github.com/yourusername/terraform-provider-netdata.git
cd terraform-provider-netdata

2. Set up your local Terraform CLI configuration file ~/.terraformrc to override the default provider installation:

provider_installation {
  dev_overrides {
    "netdata/netdata" = "<your GOBIN directory>"
  }
  direct {}
}

3. Build the provider:

make local-build

4. Now, initialize the provider in your Terraform project:

terraform init

