### PR TITLE
fix: remove exportloopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - godot
     - gofmt


### PR DESCRIPTION
solves issue:

```
ERRO [linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports.
```