### PR TITLE
fix: duplicated invitations

### DIFF
--- a/internal/provider/room_member_resource_test.go
+++ b/internal/provider/room_member_resource_test.go
@@ -14,7 +14,7 @@ func TestAccRoomMemberResource(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 				resource "netdata_space_member" "test" {
-					email    = "foo@bar.local"
+					email    = "room@member.local"
 					space_id = "%s"
 					role     = "admin"
 				}

--- a/internal/provider/space_member_resource_test.go
+++ b/internal/provider/space_member_resource_test.go
@@ -14,14 +14,14 @@ func TestAccSpaceMemberResource(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 				resource "netdata_space_member" "test" {
-					email    = "foo@bar.local"
+					email    = "space@member.local"
 					space_id = "%s"
 					role     = "admin"
 				}
 				`, getNonCommunitySpaceIDEnv()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("netdata_space_member.test", "id"),
-					resource.TestCheckResourceAttr("netdata_space_member.test", "email", "foo@bar.local"),
+					resource.TestCheckResourceAttr("netdata_space_member.test", "email", "space@member.local"),
 					resource.TestCheckResourceAttr("netdata_space_member.test", "role", "admin"),
 					resource.TestCheckResourceAttrSet("netdata_space_member.test", "space_id"),
 				),


### PR DESCRIPTION
Netdata Cloud detects whether the user has already been already invited